### PR TITLE
Authorizing org no longer works #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [unreleased]
 
+### 1.0.1
+
+**5-17-2019**
+
+- The authorization URL no longer worked because it was double encoded (#48)
+
 ### 1.0.0
 
 **4-6-2019**

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -374,7 +374,7 @@ export const AUTH_HTTP: AuthHttp = {
         response_type: `token`,
         client_id,
         scope: `api refresh_token web`,
-        redirect_uri: 'vscode%3A%2F%2Fpaustint.sfdc-qcp-vscode-extension%2Fauth_callback',
+        redirect_uri: 'vscode://paustint.sfdc-qcp-vscode-extension/auth_callback',
         prompt: 'login',
       });
       return `${domain}/services/oauth2/authorize?${params}`;


### PR DESCRIPTION
Fixed the double encoded URL when authorizing orgs

fixes #48